### PR TITLE
Fix janky animation of navigation bar.

### DIFF
--- a/Nerd Nite/NNNextEventViewController.m
+++ b/Nerd Nite/NNNextEventViewController.m
@@ -73,6 +73,12 @@ static NSString *const PresentationCellId = @"NNPresentationCell";
     [super createNavBar:@"next event"];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.navigationController setNavigationBarHidden:NO
+                                             animated:animated];
+}
+
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];

--- a/Nerd Nite/NNPastEventsViewController.m
+++ b/Nerd Nite/NNPastEventsViewController.m
@@ -43,6 +43,12 @@ static NSString *const cellId = @"PastEventCell";
     [self.eventPicturesViewController.view setFrame:CGRectMake(0, 20, navControllerFrame.size.width, navControllerFrame.size.height - 20)];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.navigationController setNavigationBarHidden:NO
+                                             animated:animated];
+}
+
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 

--- a/Nerd Nite/View Controllers/NNCitiesListViewController.m
+++ b/Nerd Nite/View Controllers/NNCitiesListViewController.m
@@ -40,9 +40,15 @@
     [self.tableView registerNib:cityCell forCellReuseIdentifier:NNCityCellId];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self.navigationController setNavigationBarHidden:YES
+                                             animated:animated];
+}
+
+
 -(void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [self.navigationController setNavigationBarHidden:YES];
     [self loadData];
 }
 

--- a/Nerd Nite/View Controllers/NNCityViewController.m
+++ b/Nerd Nite/View Controllers/NNCityViewController.m
@@ -115,6 +115,8 @@ static NSString *const presenterImageCellIdentifier = @"NNPresenterImageCollecti
 
 -(void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
+    [self.navigationController setNavigationBarHidden:NO
+                                             animated:animated];
     [self createNavBar];
 }
 

--- a/Nerd Nite/View Controllers/NNViewController.m
+++ b/Nerd Nite/View Controllers/NNViewController.m
@@ -29,7 +29,6 @@
 }
 
 -(void)createNavBar:(NSString*)title {
-    [self.navigationController setNavigationBarHidden:NO];
     [self.navigationController.navigationBar.topItem setTitle:title];
     UIFont *titleBarFont = [UIFont fontWithName:@"Courier New" size:12.0f];
     NSDictionary *titleBarTextAttributes = @{UITextAttributeFont:titleBarFont, UITextAttributeTextColor: [UIColor blackColor]};


### PR DESCRIPTION
So, this was bothering me, so I decided to fix it. Here’s the way the app currently hides the navigation bar:

![before](https://f.cloud.github.com/assets/147458/921977/b8a2964e-ff13-11e2-81cc-97af009c6853.gif)

As you can see, it jumps when the animation is finished. Eww. So, what I did is to move the view controllers’ logic for hiding the navigation bar to their `-viewWillAppear:` methods, which allows the system to do the right thing™ when animating. Here’s the same animation now:

![after](https://f.cloud.github.com/assets/147458/921978/d9b17ca6-ff13-11e2-8d92-98682f051b3b.gif)

For more info, see the one and only commit message. Enjoy!
